### PR TITLE
Add support for testing on Firefox

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -6,15 +6,20 @@ on:
 
 jobs:
   unit-test:
+    strategy:
+      matrix:
+        browser: ['chrome', 'firefox']
     runs-on: ubuntu-latest
+    name: unit-test-${{ matrix.browser }}
     steps:
       - uses: actions/checkout@v2
+      # `cache` option uses https://github.com/actions/cache under the hood with less config.
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
           cache: 'npm'
       - run: npm install
-      - run: npm run test-headless
+      - run: npm run test:${{matrix.browser}}
 
   lint:
     runs-on: ubuntu-latest

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
@@ -37,7 +38,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome','Firefox'],
     singleRun: false,
     restartOnFileChange: true
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9537,6 +9537,27 @@
         "minimatch": "^3.0.4"
       }
     },
+    "karma-firefox-launcher": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-2.1.1.tgz",
+      "integrity": "sha512-VzDMgPseXak9DtfyE1O5bB2BwsMy1zzO1kUxVW1rP0yhC4tDNJ0p3JoFdzvrK4QqVzdqUMa9Rx9YzkdFp8hz3Q==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "karma-jasmine": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma": "~6.3.4",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
+    "karma-firefox-launcher": "^2.1.1",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.7.0",
     "ng2-mock-component": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "npx ng test",
-    "test-headless": "npx ng test --browsers=ChromeHeadless --watch=false",
+    "test": "npm run test:chrome && npm run test:firefox",
+    "test:watch": "npx ng test",
+    "test:chrome": "npx ng test --browsers=ChromeHeadless --watch=false",
+    "test:firefox": "npx ng test --browsers=FirefoxHeadless --watch=false",
     "lint": "npx ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
While in theory unit tests should be browser-independent, each browser has its own JavaScript implementation, environment, etc., so it is strategically useful to automatically run tests for all supported platforms.

This PR adds Firefox support, both for interactive local testing (`npm run test -- --browsers=Firefox` or `npx ng test --browsers=Firefox`) and for CI (`npx ng test --browsers=FirefoxHeadless --watch=false` or `npm run test:firefox`).