### PR TITLE
Add testing on Edge

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -22,8 +22,14 @@ jobs:
       - run: npm run test:${{matrix.browser}}
 
   unit-test-edge:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
+      - run: curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+      - run: sudo install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
+      - run: sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
+      - run: sudo rm microsoft.gpg
+      - run: sudo apt update
+      - run: sudo apt install microsoft-edge-dev
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,7 +8,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        browser: ['chrome', 'firefox']
+        browser: ['chrome', 'firefox','edge']
     runs-on: ubuntu-latest
     name: unit-test-${{ matrix.browser }}
     steps:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -8,7 +8,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        browser: ['chrome', 'firefox','edge']
+        browser: ['chrome', 'firefox']
     runs-on: ubuntu-latest
     name: unit-test-${{ matrix.browser }}
     steps:
@@ -20,6 +20,18 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run test:${{matrix.browser}}
+
+  unit-test-edge:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - run: npm install
+      - run: npm run test:edge
+
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -22,14 +22,8 @@ jobs:
       - run: npm run test:${{matrix.browser}}
 
   unit-test-edge:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
-      - run: curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
-      - run: sudo install -o root -g root -m 644 microsoft.gpg /etc/apt/trusted.gpg.d/
-      - run: sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
-      - run: sudo rm microsoft.gpg
-      - run: sudo apt update
-      - run: sudo apt install microsoft-edge-dev
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
@@ -37,7 +31,6 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run test:edge
-
 
   lint:
     runs-on: ubuntu-latest

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
+      require('karma-edge-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
@@ -38,7 +39,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome','Firefox'],
+    browsers: ['Chrome','Firefox','Edge'],
     singleRun: false,
     restartOnFileChange: true
   });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
-      require('karma-edge-launcher'),
+      require('@chiragrupani/karma-chromium-edge-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')

--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,6 +6752,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "edge-launcher": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/edge-launcher/-/edge-launcher-1.2.2.tgz",
+      "integrity": "sha1-60Cq+9Bnpup27/+rBke81VCbN7I=",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9535,6 +9541,15 @@
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.0",
         "minimatch": "^3.0.4"
+      }
+    },
+    "karma-edge-launcher": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
+      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
+      "dev": true,
+      "requires": {
+        "edge-launcher": "1.2.2"
       }
     },
     "karma-firefox-launcher": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3644,6 +3644,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@chiragrupani/karma-chromium-edge-launcher": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chiragrupani/karma-chromium-edge-launcher/-/karma-chromium-edge-launcher-2.1.1.tgz",
+      "integrity": "sha512-QK6M+1CYMbndWRaEAOpMW9kwF+JKcqyaEY2lqe8Nnm1hyOzSZaxTqXnLTZpk7RqQHhWCOduSU/XDvceWs4H74g==",
+      "dev": true
+    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,12 +6752,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "edge-launcher": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/edge-launcher/-/edge-launcher-1.2.2.tgz",
-      "integrity": "sha1-60Cq+9Bnpup27/+rBke81VCbN7I=",
-      "dev": true
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9541,15 +9535,6 @@
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.0",
         "minimatch": "^3.0.4"
-      }
-    },
-    "karma-edge-launcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
-      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
-      "dev": true,
-      "requires": {
-        "edge-launcher": "1.2.2"
       }
     },
     "karma-firefox-launcher": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:watch": "npx ng test",
     "test:chrome": "npx ng test --browsers=ChromeHeadless --watch=false",
     "test:firefox": "npx ng test --browsers=FirefoxHeadless --watch=false",
+    "test:edge": "npx ng test --browsers=EdgeHeadless --watch=false",
     "lint": "npx ng lint",
     "e2e": "ng e2e"
   },
@@ -54,6 +55,7 @@
     "karma": "~6.3.4",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^2.1.1",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@angular-eslint/template-parser": "12.5.0",
     "@angular/cli": "~12.2.7",
     "@angular/compiler-cli": "~12.2.7",
+    "@chiragrupani/karma-chromium-edge-launcher": "^2.1.1",
     "@ngxs/devtools-plugin": "^3.7.2",
     "@types/file-saver": "^2.0.3",
     "@types/jasmine": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:watch": "npx ng test",
     "test:chrome": "npx ng test --browsers=ChromeHeadless --watch=false",
     "test:firefox": "npx ng test --browsers=FirefoxHeadless --watch=false",
-    "test:edge": "npx ng test --browsers=EdgeDevHeadless --watch=false",
+    "test:edge": "npx ng test --browsers=EdgeHeadless --watch=false",
     "lint": "npx ng lint",
     "e2e": "ng e2e"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:watch": "npx ng test",
     "test:chrome": "npx ng test --browsers=ChromeHeadless --watch=false",
     "test:firefox": "npx ng test --browsers=FirefoxHeadless --watch=false",
-    "test:edge": "npx ng test --browsers=EdgeHeadless --watch=false",
+    "test:edge": "npx ng test --browsers=EdgeDevHeadless --watch=false",
     "lint": "npx ng lint",
     "e2e": "ng e2e"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "karma": "~6.3.4",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
-    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^2.1.1",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.7.0",


### PR DESCRIPTION
### :nut_and_bolt: Description: What changed and why?

Having added Firefox testing, the next obvious target was Edge, though that is a whole different game, being from the Windows side of things.
I found a recipe to install Edge on Linux from the command-line (https://www.tecmint.com/install-microsoft-edge-browser-in-linux/), so should be able to add that to the workflow, but it seemed much simpler just to switch the environment--just run Edge testing on windows.
The catch here, though, was finding a headless Edge plugin for karma. I had originally tried `karma-edge-launcher` as the natural choice, but it does not have a headless version.
Further searching uncovered `karma-chromium-edge-launcher` which does indeed have a headless variant, and that works!

### :+1: Definition of Done

![image](https://user-images.githubusercontent.com/6817500/134754001-21ceefd6-3d9a-4100-af9e-7b101104ef63.png)

### :athletic_shoe: How to Build and Test the Change
Open a pull request.
Go to the repository's `Actions` tab in GitHub.com.
Examine the latest run.

Also, the results of the run show up in the pull request itself:

![image](https://user-images.githubusercontent.com/6817500/134754153-1ca53ca8-a99d-410a-b1a4-672ed95ec8c6.png)

Oh, note that the unit-test-edge is not showing as required in the image.
That is an admin-configuration update in the repository, which has now been done (Settings >> Branches >> Branch Protection Rules).

### :chains: Related Resources

NA
