### PR TITLE
add markdownlint check to CI

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -48,4 +48,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install -g markdownlint-cli
-      - run: markdownlint '**/*.md' --ignore node_modules
+      - run: npm run markdownlint

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -42,3 +42,10 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run lint
+
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm install -g markdownlint-cli
+      - run: markdownlint '**/*.md' --ignore node_modules

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ What I wanted to do was create a modern web app from scratch using best design p
 as a showcase piece for my portfolio.
 And this seemed like a project that was small enough to make it the amount of code easy to digest for a reader, yet still require quite a bit of different patterns, interfaces, and libraries to make it interesting.
 
-So, yes, this is a real, working web app; not a toy or demo. 
+So, yes, this is a real, working web app; not a toy or demo.
 
 These are the high-level requirements I began with:
 

--- a/README.md
+++ b/README.md
@@ -476,8 +476,9 @@ Here are some of the UX considerations applied to this application to provide th
 
 ###  6.3. <a name='DeveloperExperienceToo'></a>Developer Experience, Too
 
-UX is not just for users--it applies to developers, too!
+UX is not just for users--developer experience (DX) is important, too!
 I strive to make code welcoming in a sense, so people who want to either read the code or just understand how the application works, can easily dig in.
+
 Some examples:
 
 * A thorough read-me file is supplied ( this one :-).
@@ -495,6 +496,8 @@ But rather than just provide the bits, I included comments in that file explaini
 * More on comments: some comments are vital, as in the previous bullet.
 But care must be taken to use comments appropriately and only when necessary, because too many comments can often be worse than not enough.
 I wrote at length about this in [Fighting Evil in Your Code: Comments on Comments](https://www.simple-talk.com/opinion/opinion-pieces/fighting-evil-code-comments-comments/)
+
+* CI checks help minimize the developer burden, automatically running checks on different browsers, and even a markdownlint check, too.
 
 ##  7. <a name='Performance'></a>Performance
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ What I wanted to do was create a modern web app from scratch using best design p
 as a showcase piece for my portfolio.
 And this seemed like a project that was small enough to make it the amount of code easy to digest for a reader, yet still require quite a bit of different patterns, interfaces, and libraries to make it interesting.
 
-So, yes, this is a real, working web app; not a toy or demo.
+So, yes, this is a real, working web app; not a toy or demo. 
 
 These are the high-level requirements I began with:
 

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,7 @@
     "words": [
         "kineograph",
         "kludgy",
+        "markdownlint",
         "ngrx",
         "ngxs",
         "scroller",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:firefox": "npx ng test --browsers=FirefoxHeadless --watch=false",
     "test:edge": "npx ng test --browsers=EdgeHeadless --watch=false",
     "lint": "npx ng lint",
+    "markdownlint": "markdownlint '**/*.md' --ignore node_modules",
     "e2e": "ng e2e"
   },
   "private": true,


### PR DESCRIPTION
### :nut_and_bolt: Description: What changed and why?

Markdownlint is a great aid as a VSCode plugin while writing documentation files.
This PR adds a markdownlint check for all markdown files in the repository (**/*.md) to the CI suite to assure errors do not creep in.

### :+1: Definition of Done

(1) `npm run markdownlint` is available locally on the command line to check for any markdown issues.
(2) markdownlint is automatically run in CI.

Markdownlint failures will force the build to fail:

![image](https://user-images.githubusercontent.com/6817500/134840417-c3f259b9-8fd4-410b-823e-e83fd9b4a573.png)

### :athletic_shoe: How to Build and Test the Change

Open a PR and observe that `markdownlint` is now among the list of checks that are run.
You can induce a markdownlint failure by, e.g., adding a space at the end of any line of a markdown file.
For convenience, there is an induced error in the PR; to expose it just run `git reset HEAD~1` after you have downloaded the branch.

### :chains: Related Resources

NA